### PR TITLE
script/pull_github_pr.sh: merge PR with single commit

### DIFF
--- a/scripts/pull_github_pr.sh
+++ b/scripts/pull_github_pr.sh
@@ -72,19 +72,8 @@ nr_commits=$(git log --pretty=oneline HEAD..FETCH_HEAD | wc -l)
 closes="${NL}${NL}Closes ${PROJECT}#${PR_NUM}${NL}"
 
 if [[ $nr_commits == 1 ]]; then
-	commit=$(git log --pretty=oneline HEAD..FETCH_HEAD | awk '{print $1}')
-	message="$(git log -1 "$commit" --format="format:%s%n%n%b")"
-	if ! git cherry-pick $commit
-	then
-		echo "Cherry-pick failed. You are now in a subshell. Either resolve with git cherry-pick --continue or git cherry-pick --abort, then exit the subshell"
-		head_before=$(git rev-parse HEAD)
-		bash
-		head_after=$(git rev-parse HEAD)
-		if [[ "$head_before" = "$head_after" ]]; then
-			exit 1
-		fi
-	fi
-	git commit --amend -m "${message}${closes}"
+	git merge --squash FETCH_HEAD
+	git commit -m "Merge '$PR_TITLE' from $USER_NAME" -m "${PR_DESCR}${closes}"
 else
 	git merge --no-ff --log=1000 FETCH_HEAD -m "Merge '$PR_TITLE' from $USER_NAME" -m "${PR_DESCR}${closes}"
 fi


### PR DESCRIPTION
Today for a single commit PR we do a rebase to next using pull_github_pr.sh script rather than merge, making our PR closed instead of merging, which means we don't have a merge commit in GitHub API (Mergify is looking for this value)

So instead of doing rebase, let's merge the single commit and add the `Closes` prefix as a git note (this will apply for both single commit and multiple commits PR).

This will allow us to have the proper reference with `git log` but the PR will be merged instead of closed when the commit is promoted


**no backport is needed**